### PR TITLE
Make Language struct to only add languages in one place

### DIFF
--- a/src/lang/brainfuck.rs
+++ b/src/lang/brainfuck.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use indoc::indoc;
 
+use crate::lang::Language2;
+
 use super::LangWriter;
 
 pub const NAME: &str = "brainfuck";
@@ -24,7 +26,14 @@ pub const HELP: &str = indoc!(
     "#
 );
 
-pub fn interpret<T: LangWriter>(pgm_str: &str, input_str: &str, _args: &str, writer: &mut T) {
+pub static IMPL: Language2 = Language2 {
+    name: NAME,
+    help: HELP,
+    homepage: HOMEPAGE,
+    interpret,
+};
+
+pub fn interpret(pgm_str: &str, input_str: &str, _args: &str, writer: &mut dyn LangWriter) {
     let pgm = String::from(pgm_str).into_bytes();
     let mut input = input_str.bytes();
 

--- a/src/lang/deadfish.rs
+++ b/src/lang/deadfish.rs
@@ -1,5 +1,8 @@
-use super::LangWriter;
 use indoc::indoc;
+
+use crate::lang::Language2;
+
+use super::LangWriter;
 
 pub const NAME: &str = "Deadfish";
 pub const HOMEPAGE: &str = "https://esolangs.org/wiki/Deadfish";
@@ -13,7 +16,15 @@ pub const HELP: &str = indoc!(
     "#
 );
 
-pub fn interpret<T: LangWriter>(pgm: &str, _input: &str, args: &str, writer: &mut T) {
+pub static IMPL: Language2 = Language2 {
+    name: NAME,
+    help: HELP,
+    homepage: HOMEPAGE,
+    interpret,
+};
+
+
+pub fn interpret(pgm: &str, _input: &str, args: &str, writer: &mut dyn LangWriter) {
     let mut counter = 0_u32;
     let is_char_output = args == "-o";
     for b in pgm.bytes() {

--- a/src/lang/example_lang.rs
+++ b/src/lang/example_lang.rs
@@ -1,81 +1,81 @@
-use super::LangWriter;
-use indoc::indoc;
+// use super::LangWriter;
+// use indoc::indoc;
 
 pub const NAME: &str = "ExampleLang";
-pub const HOMEPAGE: &str = "https://example.com";
-pub const HELP: &str = indoc!(
-    r#"
-    An example language for debugging purposes.
-
-    program == "lang": Print some chars on stdout and stderr, and halt (fast).
-    program == "slow": Print some chars on stdout and stderr, and halt (slow).
-    program == "crasher": Print some chars but crash after a while.
-    program == "looper": Print things very slowly, forever.
-    program == "talker": Print things very fast, exceeding the output limit.
-    "#
-);
-
-pub fn interpret<T: LangWriter>(pgm: &str, input: &str, args: &str, writer: &mut T) {
-    match pgm {
-        "lang" => interpret_lang(pgm, input, args, writer),
-        "slow" => interpret_slow(pgm, input, args, writer),
-        "crasher" => interpret_crasher(pgm, input, args, writer),
-        "looper" => interpret_looper(pgm, input, args, writer),
-        "talker" => interpret_talker(pgm, input, args, writer),
-        _ => writer.write_err(&format!("Unrecognized program: {}", pgm)),
-    }
-}
-
-fn interpret_lang<T: LangWriter>(_pgm: &str, _input: &str, _args: &str, writer: &mut T) {
-    for i in 0..40 {
-        writer.write_both("S", &format!("{}", i));
-    }
-    writer.terminate();
-}
-
-fn interpret_slow<T: LangWriter>(_pgm: &str, _input: &str, _args: &str, writer: &mut T) {
-    for i in 0..400_000_000 {
-        if i % 10_000_000 == 0 {
-            writer.write_both("S", &format!("{}", i / 10_000_000 % 10));
-        }
-    }
-    writer.terminate();
-}
-
-fn interpret_crasher<T: LangWriter>(_pgm: &str, _input: &str, _args: &str, writer: &mut T) {
-    for i in 0..400_000_000 {
-        if i % 10_000_000 == 0 {
-            writer.write_both("S", &format!("{}", i / 10_000_000 % 10));
-        }
-    }
-    panic!("wtf");
-}
-
-fn interpret_looper<T: LangWriter>(_pgm: &str, _input: &str, _args: &str, writer: &mut T) {
-    let mut i = 0;
-    loop {
-        if i % 10_000_000 == 0 {
-            writer.write_both("S", &format!("{}", i / 10_000_000 % 10));
-            if i >= 100_000_000 {
-                i = 0;
-            }
-        }
-        i += 1;
-    }
-}
-
-fn interpret_talker<T: LangWriter>(_pgm: &str, _input: &str, _args: &str, writer: &mut T) {
-    let mut i = 0;
-    loop {
-        if i % 100 == 0 {
-            writer.write_out("S");
-        }
-        if i % 100_000 == 0 {
-            writer.write_err(&format!("{}", i / 100_000 % 10));
-            if i >= 100_000_000 {
-                i = 0;
-            }
-        }
-        i += 1;
-    }
-}
+// pub const HOMEPAGE: &str = "https://example.com";
+// pub const HELP: &str = indoc!(
+//     r#"
+//     An example language for debugging purposes.
+//
+//     program == "lang": Print some chars on stdout and stderr, and halt (fast).
+//     program == "slow": Print some chars on stdout and stderr, and halt (slow).
+//     program == "crasher": Print some chars but crash after a while.
+//     program == "looper": Print things very slowly, forever.
+//     program == "talker": Print things very fast, exceeding the output limit.
+//     "#
+// );
+//
+// pub fn interpret(pgm: &str, input: &str, args: &str, writer: &mut dyn LangWriter) {
+//     match pgm {
+//         "lang" => interpret_lang(pgm, input, args, writer),
+//         "slow" => interpret_slow(pgm, input, args, writer),
+//         "crasher" => interpret_crasher(pgm, input, args, writer),
+//         "looper" => interpret_looper(pgm, input, args, writer),
+//         "talker" => interpret_talker(pgm, input, args, writer),
+//         _ => writer.write_err(&format!("Unrecognized program: {}", pgm)),
+//     }
+// }
+//
+// fn interpret_lang(_pgm: &str, _input: &str, _args: &str, writer: &mut dyn LangWriter) {
+//     for i in 0..40 {
+//         writer.write_both("S", &format!("{}", i));
+//     }
+//     writer.terminate();
+// }
+//
+// fn interpret_slow(_pgm: &str, _input: &str, _args: &str, writer: &mut dyn LangWriter) {
+//     for i in 0..400_000_000 {
+//         if i % 10_000_000 == 0 {
+//             writer.write_both("S", &format!("{}", i / 10_000_000 % 10));
+//         }
+//     }
+//     writer.terminate();
+// }
+//
+// fn interpret_crasher(_pgm: &str, _input: &str, _args: &str, writer: &mut dyn LangWriter) {
+//     for i in 0..400_000_000 {
+//         if i % 10_000_000 == 0 {
+//             writer.write_both("S", &format!("{}", i / 10_000_000 % 10));
+//         }
+//     }
+//     panic!("wtf");
+// }
+//
+// fn interpret_looper(_pgm: &str, _input: &str, _args: &str, writer: &mut dyn LangWriter) {
+//     let mut i = 0;
+//     loop {
+//         if i % 10_000_000 == 0 {
+//             writer.write_both("S", &format!("{}", i / 10_000_000 % 10));
+//             if i >= 100_000_000 {
+//                 i = 0;
+//             }
+//         }
+//         i += 1;
+//     }
+// }
+//
+// fn interpret_talker(_pgm: &str, _input: &str, _args: &str, writer: &mut dyn LangWriter) {
+//     let mut i = 0;
+//     loop {
+//         if i % 100 == 0 {
+//             writer.write_out("S");
+//         }
+//         if i % 100_000 == 0 {
+//             writer.write_err(&format!("{}", i / 100_000 % 10));
+//             if i >= 100_000_000 {
+//                 i = 0;
+//             }
+//         }
+//         i += 1;
+//     }
+// }

--- a/src/lang/s10k.rs
+++ b/src/lang/s10k.rs
@@ -1,5 +1,8 @@
-use super::LangWriter;
 use indoc::indoc;
+
+use crate::lang::Language2;
+
+use super::LangWriter;
 
 pub const NAME: &str = "S10K";
 pub const HOMEPAGE: &str = "https://try-in-browser.netlify.app/";
@@ -10,7 +13,15 @@ pub const HELP: &str = indoc!(
     "#
 );
 
-pub fn interpret<T: LangWriter>(_pgm: &str, _input: &str, _args: &str, writer: &mut T) {
+pub static IMPL: Language2 = Language2 {
+    name: NAME,
+    help: HELP,
+    homepage: HOMEPAGE,
+    interpret,
+};
+
+
+pub fn interpret(_pgm: &str, _input: &str, _args: &str, writer: &mut dyn LangWriter) {
     writer.write_out(&"S".repeat(10000));
     writer.terminate();
 }


### PR DESCRIPTION
Somewhat messy, but this allows you to only add a language in one place in `lang/mod.rs`. However, since it uses a global immutable variable, you can't add the example language based on the config. I think that's alright, though. I'm also not sure if the functions need to be references or not, or if `Language` should be a trait so that `dyn Language` can be used.